### PR TITLE
AlertNote コンポーネントを実装する

### DIFF
--- a/src/components/content/AlertNote.vue
+++ b/src/components/content/AlertNote.vue
@@ -1,0 +1,47 @@
+<script lang="ts" setup>
+import { computed } from '#imports'
+
+type Alert = 'note' | 'tip' | 'important' | 'warning' | 'caution'
+type NoteColor = 'primary' | 'green' | 'purple' | 'yellow' | 'red'
+
+const props = withDefaults(
+  defineProps<{ type?: Alert }>(),
+  { type: 'note' },
+)
+
+const color = computed<NoteColor>(() => {
+  if (props.type === 'note') {
+    return 'primary'
+  }
+
+  if (props.type === 'tip') {
+    return 'green'
+  }
+
+  if (props.type === 'important') {
+    return 'purple'
+  }
+
+  if (props.type === 'warning') {
+    return 'yellow'
+  }
+
+  if (props.type === 'caution') {
+    return 'red'
+  }
+
+  return 'primary'
+})
+</script>
+
+<template>
+  <UAlert
+    variant="soft"
+    :color="color"
+    :ui="{ padding: 'px-2 py-0 my-1' }"
+  >
+    <template #description>
+      <slot />
+    </template>
+  </UAlert>
+</template>

--- a/src/content/tech/testing-markdown-renderer.md
+++ b/src/content/tech/testing-markdown-renderer.md
@@ -9,6 +9,10 @@ publishedAt: '2024-08-16'
 updatedAt: '2024-08-16'
 ---
 
+マークダウンのパースがどうされるのかを確認するためのページ。
+
+異常がないかを確かめるデバッグ用にも使用します。
+
 ## 見出し
 
 ```text
@@ -50,6 +54,35 @@ updatedAt: '2024-08-16'
 ```
 
 *イタリック* **太字** ~~打ち消し線~~ `code`
+
+## Vue Custom Components
+
+`~/components/content` ディレクトリにあるコンポーネントはマークダウンで使用できるので、サンプルを表示する。
+
+### AlertNote
+
+<!-- textlint-disable -->
+::AlertNote{type='note'}
+type='note'
+::
+
+::AlertNote{type='important'}
+type='important'
+::
+
+::AlertNote{type='tip'}
+type='tip'
+::
+
+::AlertNote{type='warning'}
+type='warning'
+::
+
+::AlertNote{type='caution'}
+type='caution'
+::
+<!-- textlint-enable -->
+
 
 ## コードブロック
 

--- a/src/content/tech/testing-markdown-renderer.md
+++ b/src/content/tech/testing-markdown-renderer.md
@@ -83,7 +83,6 @@ type='caution'
 ::
 <!-- textlint-enable -->
 
-
 ## コードブロック
 
 ### diff

--- a/src/content/work/benefit-and-pain-came-along-with-multiple-works.md
+++ b/src/content/work/benefit-and-pain-came-along-with-multiple-works.md
@@ -7,9 +7,7 @@ updatedAt: '2024-10-07'
 ---
 
 <!-- textlint-disable -->
-::UAlert{variant="soft" color="primary" :ui='{"padding": "px-2 py-0"}'}
-<!-- markdownlint-disable-next-line -->
-#description
+::AlertNote{type='note'}
 この記事はあくまで個人の感想になります。参考程度にとどめてもらえると幸いです。
 ::
 <!-- textlint-enable -->


### PR DESCRIPTION
## やりたいこと
 - GitHub や esa のマークダウンで [alert 表示](https://docs.github.com/ja/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#alerts)があり、これに似たようなものを記事に表示できるように `AlertNote` コンポーネントを作る