### PR TITLE
レスポンシブで使う処理を nuxtjs/device に寄せる

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -40,7 +40,13 @@ export default defineNuxtConfig({
     dirs: [],
   },
 
-  modules: ['@nuxt/content', '@nuxt/ui', '@nuxt/image', '@nuxt/eslint'],
+  modules: [
+    '@nuxt/content',
+    '@nuxt/ui',
+    '@nuxt/image',
+    '@nuxt/eslint',
+    '@nuxtjs/device',
+  ],
 
   eslint: {
     config: {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "preview": "nuxt preview",
     "postinstall": "nuxt prepare",
     "prepare": "nuxt prepare",
+    "module:add": "nuxi module add",
     "lint": "npm run lint:eslint && npm run lint:markdown && npm run lint:text",
     "lint:eslint": "eslint .",
     "lint:markdown": "markdownlint-cli2 src/content/**/*.md",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@nuxt/content": "2.13.2",
     "@nuxt/image": "1.7.0",
     "@nuxt/ui": "2.18.4",
+    "@nuxtjs/device": "3.2.4",
     "nuxt": "3.12.4",
     "sitemap": "8.0.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@nuxt/ui':
         specifier: 2.18.4
         version: 2.18.4(magicast@0.3.4)(rollup@4.20.0)(vite@5.4.0(@types/node@22.1.0)(terser@5.31.5))(vue@3.4.36(typescript@5.5.4))
+      '@nuxtjs/device':
+        specifier: 3.2.4
+        version: 3.2.4
       nuxt:
         specifier: 3.12.4
         version: 3.12.4(@parcel/watcher@2.4.1)(@types/node@22.1.0)(eslint@9.9.0(jiti@1.21.6))(ioredis@5.4.1)(magicast@0.3.4)(optionator@0.9.4)(rollup@4.20.0)(terser@5.31.5)(typescript@5.5.4)(vite@5.4.0(@types/node@22.1.0)(terser@5.31.5))
@@ -1097,6 +1100,9 @@ packages:
 
   '@nuxtjs/color-mode@3.4.2':
     resolution: {integrity: sha512-6A+lDP8R6fFXc1Ip5tDepKq9MJW6oxbRlz1plvW52yacnpeDFXv5S5rDS0ax31AuSFUPlgzHymFSdjcylBwZ6w==}
+
+  '@nuxtjs/device@3.2.4':
+    resolution: {integrity: sha512-jIvN6QeodBNrUrL/1FCHk4bebsiLsGHlJd8c/m2ksLrGY4IZ0npA8IYhDTdYV92epGxoe8+3iZOzCjav+6TshQ==}
 
   '@nuxtjs/mdc@0.8.3':
     resolution: {integrity: sha512-FqvJFWkBN9u2FeWog+7+C0aIOx0WIu61TYgAXPmmIOVVua6s2mXQsMyF3fXY2M56QBIaYJzK/SYN+5FGr5GNTQ==}
@@ -7678,6 +7684,10 @@ snapshots:
       - magicast
       - rollup
       - supports-color
+
+  '@nuxtjs/device@3.2.4':
+    dependencies:
+      defu: 6.1.4
 
   '@nuxtjs/mdc@0.8.3(magicast@0.3.4)(rollup@4.20.0)':
     dependencies:

--- a/src/components/header/AppHeader.vue
+++ b/src/components/header/AppHeader.vue
@@ -1,16 +1,9 @@
 <script setup lang="ts">
-import { useMatchMediaListener, onMounted, ref } from '#imports'
+import { useDevice } from '#imports'
 
 import ColorModeToggle from '~/components/header/ColorModeToggle.vue'
 
-const isMobile = ref(false)
-onMounted(() => {
-  const toggleIsMobile = (mql: MediaQueryList | MediaQueryListEvent): void => {
-    isMobile.value = !mql.matches
-  }
-  const { setMatchMediaHandler } = useMatchMediaListener()
-  setMatchMediaHandler(toggleIsMobile)
-})
+const device = useDevice()
 </script>
 
 <template>
@@ -35,7 +28,7 @@ onMounted(() => {
           size="2xs"
           :ui="{ icon: { size: { '2xs': 'w-3 h-3' } } }"
         >
-          {{ isMobile ? '' : 'About' }}
+          {{ device.isMobile ? '' : 'About' }}
         </UButton>
 
         <UButton
@@ -47,7 +40,7 @@ onMounted(() => {
           size="2xs"
           :ui="{ icon: { size: { '2xs': 'w-3 h-3' } } }"
         >
-          {{ isMobile ? '' : 'Music' }}
+          {{ device.isMobile ? '' : 'Music' }}
         </UButton>
 
         <UButton
@@ -59,7 +52,7 @@ onMounted(() => {
           size="2xs"
           :ui="{ icon: { size: { '2xs': 'w-3 h-3' } } }"
         >
-          {{ isMobile ? '' : 'Bartender' }}
+          {{ device.isMobile ? '' : 'Bartender' }}
         </UButton>
 
         <UButton
@@ -71,7 +64,7 @@ onMounted(() => {
           size="2xs"
           :ui="{ icon: { size: { '2xs': 'w-3 h-3' } } }"
         >
-          {{ isMobile ? '' : 'Posts' }}
+          {{ device.isMobile ? '' : 'Posts' }}
         </UButton>
 
         <div class="w-6 h-3">


### PR DESCRIPTION
## やりたいこと
 - レスポンシブのために match media を使用しており、ブラウザの js の `onMounted` で端末がモバイルなのかを判定している。これは HTML が返ってきたあとの js で実行されている、そのためモバイルでアクセスしたときには、PC 表示の HTML が先にブラウザに返り、その後 js で SP 表示へ切り替えることから少しラグが生じてしまう。
 - なので、ブラウザの `onMounted` で切り替えるのではなく、リクエスト時の user agent でレスポンシブを可能にするように `@nuxtjs/device` を使用する