### PR TITLE
末尾の trailing slash を削除する

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -28,6 +28,7 @@ export default defineNuxtConfig({
     preset: 'cloudflare-pages',
 
     prerender: {
+      autoSubfolderIndex: true,
       routes: getContentRoutes(),
     },
   },


### PR DESCRIPTION
## やりたいこと
 - google search console でインデックスされているページを見ると、記事のページに末尾にスラッシュがあるないの両方が登録されている。SEO 的に重複している内容を登録させるのはよくないので、末尾からスラッシュをなくす