### PR TITLE
ヘッダーのレスポンシブ修正 (3回目)

### DIFF
--- a/src/components/header/AppHeader.vue
+++ b/src/components/header/AppHeader.vue
@@ -1,9 +1,5 @@
 <script setup lang="ts">
-import { useDevice } from '#imports'
-
 import ColorModeToggle from '~/components/header/ColorModeToggle.vue'
-
-const device = useDevice()
 </script>
 
 <template>
@@ -24,11 +20,21 @@ const device = useDevice()
           to="/about"
           color="gray"
           variant="ghost"
-          class="p-0.5"
+          class="p-0.5 inline-flex pc:hidden"
+          size="2xs"
+          :ui="{ icon: { size: { '2xs': 'w-3 h-3' } } }"
+        />
+
+        <UButton
+          icon="i-heroicons-user-circle"
+          to="/about"
+          color="gray"
+          variant="ghost"
+          class="p-0.5 pc:inline-flex hidden"
           size="2xs"
           :ui="{ icon: { size: { '2xs': 'w-3 h-3' } } }"
         >
-          {{ device.isMobile ? '' : 'About' }}
+          About
         </UButton>
 
         <UButton
@@ -36,11 +42,21 @@ const device = useDevice()
           to="/music"
           color="gray"
           variant="ghost"
-          class="p-0.5"
+          class="p-0.5 inline-flex pc:hidden"
+          size="2xs"
+          :ui="{ icon: { size: { '2xs': 'w-3 h-3' } } }"
+        />
+
+        <UButton
+          icon="i-heroicons-musical-note"
+          to="/music"
+          color="gray"
+          variant="ghost"
+          class="p-0.5 pc:inline-flex hidden"
           size="2xs"
           :ui="{ icon: { size: { '2xs': 'w-3 h-3' } } }"
         >
-          {{ device.isMobile ? '' : 'Music' }}
+          Music
         </UButton>
 
         <UButton
@@ -48,11 +64,21 @@ const device = useDevice()
           to="/bartender"
           color="gray"
           variant="ghost"
-          class="p-0.5"
+          class="p-0.5 inline-flex pc:hidden"
+          size="2xs"
+          :ui="{ icon: { size: { '2xs': 'w-3 h-3' } } }"
+        />
+
+        <UButton
+          icon="i-heroicons-funnel"
+          to="/bartender"
+          color="gray"
+          variant="ghost"
+          class="p-0.5 pc:inline-flex hidden"
           size="2xs"
           :ui="{ icon: { size: { '2xs': 'w-3 h-3' } } }"
         >
-          {{ device.isMobile ? '' : 'Bartender' }}
+          Bartender
         </UButton>
 
         <UButton
@@ -60,11 +86,21 @@ const device = useDevice()
           to="/posts/1"
           color="gray"
           variant="ghost"
-          class="p-0.5"
+          class="p-0.5 inline-flex pc:hidden"
+          size="2xs"
+          :ui="{ icon: { size: { '2xs': 'w-3 h-3' } } }"
+        />
+
+        <UButton
+          icon="i-heroicons-document"
+          to="/posts/1"
+          color="gray"
+          variant="ghost"
+          class="p-0.5 pc:inline-flex hidden"
           size="2xs"
           :ui="{ icon: { size: { '2xs': 'w-3 h-3' } } }"
         >
-          {{ device.isMobile ? '' : 'Posts' }}
+          Posts
         </UButton>
 
         <div class="w-6 h-3">


### PR DESCRIPTION
## やりたいこと
 - nuxt/device を入れてヘッダーのレスポンシブに対応したが、やはり最初 prerender された html がヘッダーアイコンの隣に文字があるため、最初画面外まではみ出て js が後で文字を非表示にするという処理でちらつきが発生する。 
 - SEO 的懸念があるため、display: none をさけていたが、ちらつきが発生するよりかはベターなので、この対応を行う。
 - トップも含め、ヘッダーデザインは大幅にリニューアルする。