### PR TITLE
CI 用の generate コマンドを追加

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -31,7 +31,7 @@ jobs:
 
       - run: pnpm install
 
-      - run: pnpm run generate
+      - run: pnpm run generate:ci
 
       - name: Build & Deploy Worker
         uses: cloudflare/wrangler-action@v3

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,7 +25,7 @@ jobs:
 
       - run: pnpm install
 
-      - run: pnpm run generate
+      - run: pnpm run generate:ci
 
       - name: Build & Deploy Worker
         uses: cloudflare/wrangler-action@v3

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "build": "nuxt build",
     "dev": "concurrently --kill-others \"pnpm run dev:functions --port=8789\" \"nuxt dev\"",
     "generate": "nuxt generate",
+    "generate:ci": "pnpm run dev:functions --port=8789 & sleep 2 && pnpm run generate",
     "preview": "nuxt preview",
     "postinstall": "nuxt prepare",
     "prepare": "nuxt prepare",


### PR DESCRIPTION
## やりたいこと
 - CI では concurrently を使ってサーバー起動と nuxt  generate を行うと status 1 となりエラー扱いとなってしまう。なので、プロセス制御は github action に任せることにする。これによりローカルで行うデプロイと ci で行うデプロイでコマンドが違うので、違うコマンドを用意する