### PR TITLE
nuxt ui の global 化をやめる

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -77,10 +77,6 @@ export default defineNuxtConfig({
 
   srcDir: 'src', // プロジェクト全体の設定ファイルと nuxt 関連のファイルを混ぜないようにするため
 
-  ui: {
-    global: true,
-  },
-
   content: {
     markdown: {
       rehypePlugins: [


### PR DESCRIPTION
## やりたいこと
 - nuxt ui のコンポーネントをマークダウンで使いたいがために、global コンポーネントとして登録していたが、必要なものだけ content ディレクトリに保存して、global 登録できる。なので、ui の global オプションは false にして、js と css のサイズを減らす